### PR TITLE
chore: automatically deploy the release to the PyPi repository.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,8 @@ jobs:
           asset_path: ./dist/report2junit-${{ steps.vars.outputs.version }}.tar.gz
           asset_name: report2junit-${{ steps.vars.outputs.version }}.tar.gz
           asset_content_type: application/tar+gzip
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: Nr18
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ report2junit --source-type cfn-nag ./sample-reports/cfn-nag.json ./sample-report
 
 ## Releases
 
- First you will need to update the `version` in the [`pyproject.toml`](./pyproject.toml) file. Then you need to create a
- new release. You can do this by creating a tag and push it to the remote:
+First you will need to update the `version` in the [`pyproject.toml`](./pyproject.toml) file. Next you need to merge the
+change to the `main` branch using a pull request.
+
+Then you need to create a new release. You can do this by creating a tag and push it to the remote:
 
  ```bash
  git tag v$(awk '/version/{print $NF}'  pyproject.toml | sed 's/\"//g')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "report2junit"
-version = "0.0.2"
+version = "0.0.3"
 description = "`report2junit` is a tool that converts various reports into the JUnit format."
 authors = ["Joris Conijn <joris@conijnonline.nl>"]
 license = "MIT"


### PR DESCRIPTION
Use GitHub Actions to automatically upload the release to the PyPi repository.