### PR TITLE
fix: move release procedure to CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
+information to effectively respond to your bug report or contribution.
+
+## Reporting Bugs/Feature Requests
+
+We welcome you to use the GitHub issue tracker to report bugs, suggest features, or documentation improvements.
+
+When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
+reported the issue. Please try to include as much information as you can.
+
+
+## Releases
+
+First you will need to update the `version` in the [`pyproject.toml`](./pyproject.toml) file. Next you need to merge the
+change to the `main` branch using a pull request.
+
+Then you need to create a new release. You can do this by creating a tag and push it to the remote:
+
+ ```bash
+ git tag v$(awk '/version/{print $NF}'  pyproject.toml | sed 's/\"//g')
+ git push --tags
+ ```
+
+ This will trigger the GitHub Actions [`release`](.github/workflows/release.yml) workflow.

--- a/README.md
+++ b/README.md
@@ -44,17 +44,3 @@ report2junit --source-type cfn-nag ./sample-reports/cfn-nag.json
 # Or if you want to specify the destination:
 report2junit --source-type cfn-nag ./sample-reports/cfn-nag.json ./sample-reports/cfn-nag-other-destination.xml
 ```
-
-## Releases
-
-First you will need to update the `version` in the [`pyproject.toml`](./pyproject.toml) file. Next you need to merge the
-change to the `main` branch using a pull request.
-
-Then you need to create a new release. You can do this by creating a tag and push it to the remote:
-
- ```bash
- git tag v$(awk '/version/{print $NF}'  pyproject.toml | sed 's/\"//g')
- git push --tags
- ```
-
- This will trigger the GitHub Actions [`release`](.github/workflows/release.yml) workflow.

--- a/poetry.lock
+++ b/poetry.lock
@@ -61,26 +61,6 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [[package]]
-name = "build"
-version = "0.7.0"
-description = "A simple, correct PEP517 package builder"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-colorama = {version = "*", markers = "os_name == \"nt\""}
-packaging = ">=19.0"
-pep517 = ">=0.9.1"
-tomli = ">=1.0.0"
-
-[package.extras]
-docs = ["furo (>=2020.11.19b18)", "sphinx (>=3.0,<4.0)", "sphinx-argparse-cli (>=1.5)", "sphinx-autodoc-typehints (>=1.10)"]
-test = ["filelock (>=3)", "pytest (>=6.2.4)", "pytest-cov (>=2)", "pytest-mock (>=2)", "pytest-rerunfailures (>=9.1)", "pytest-xdist (>=1.34)", "setuptools (>=42.0.0)", "toml (>=0.10.0)", "wheel (>=0.36.0)"]
-typing = ["importlib-metadata (>=4.6.4)", "mypy (==0.910)", "typing-extensions (>=3.7.4.3)"]
-virtualenv = ["virtualenv (>=20.0.35)"]
-
-[[package]]
 name = "certifi"
 version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -272,7 +252,7 @@ python-versions = "*"
 name = "packaging"
 version = "21.0"
 description = "Core utilities for Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -286,17 +266,6 @@ description = "Utility library for gitignore style pattern matching of file path
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-
-[[package]]
-name = "pep517"
-version = "0.12.0"
-description = "Wrappers to build Python packages using PEP 517 hooks"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-tomli = {version = ">=1.1.0", markers = "python_version >= \"3.6\""}
 
 [[package]]
 name = "pkginfo"
@@ -361,7 +330,7 @@ python-versions = ">=3.5"
 name = "pyparsing"
 version = "3.0.3"
 description = "Python parsing module"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -508,7 +477,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "tomli"
 version = "1.2.2"
 description = "A lil' TOML parser"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -599,7 +568,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "63cb83e3835c2f13030314ca8e34148ecf32a1f8265fcd39fcccde684a02f93d"
+content-hash = "fae77b5fc56f367abf1e50f3e2fab05e8000d60136d43e391f59ac46c6554180"
 
 [metadata.files]
 atomicwrites = [
@@ -617,10 +586,6 @@ black = [
 bleach = [
     {file = "bleach-4.1.0-py2.py3-none-any.whl", hash = "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"},
     {file = "bleach-4.1.0.tar.gz", hash = "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da"},
-]
-build = [
-    {file = "build-0.7.0-py3-none-any.whl", hash = "sha256:21b7ebbd1b22499c4dac536abc7606696ea4d909fd755e00f09f3c0f2c05e3c8"},
-    {file = "build-0.7.0.tar.gz", hash = "sha256:1aaadcd69338252ade4f7ec1265e1a19184bf916d84c9b7df095f423948cb89f"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -810,10 +775,6 @@ packaging = [
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
-]
-pep517 = [
-    {file = "pep517-0.12.0-py2.py3-none-any.whl", hash = "sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161"},
-    {file = "pep517-0.12.0.tar.gz", hash = "sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0"},
 ]
 pkginfo = [
     {file = "pkginfo-1.7.1-py2.py3-none-any.whl", hash = "sha256:37ecd857b47e5f55949c41ed061eb51a0bee97a87c969219d144c0e023982779"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ license = "MIT"
 python = "^3.8"
 junit-xml = "^1.9"
 click = "^8.0.3"
-build = "^0.7.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.9b0"


### PR DESCRIPTION
The release workflow failed due to:

> `long_description` has syntax errors in markup and would not be rendered on PyPI.

The only change made to the README.md was the addition of the release procedure. Because the README.md is also used as a package description it does not make sense to include the release procedure in that description. Therefor I moved it to the CONTRIBUTING.md file where it makes more sense.