### PR TITLE
refactor: replace source-type option with auto detect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ __pycache__
 .pytest_cache
 .mypy_cache
 .idea
-reports
+/reports
 *.egg-info
 dist
 .coverage

--- a/report2junit/__init__.py
+++ b/report2junit/__init__.py
@@ -1,20 +1,23 @@
 import os.path
-from typing import Optional, Type
+from typing import Optional
 
 import click
 
-from report2junit.reports import available_reports, ReportFactory
+from report2junit.reports import fetch_report, ReportFactory
 
 
 @click.command()
 @click.option(
+    # DEPRECATED source type is being auto-detected, this option will be removed in a future release.
     "--source-type",
-    type=click.Choice(list(available_reports.keys()), case_sensitive=False),
-    required=True,
+    type=click.Choice(["cfn-guard", "cfn-nag"], case_sensitive=False),
+    required=False,
 )
 @click.argument("source-file")
 @click.argument("destination-file", required=False)
-def main(source_file: str, source_type: str, destination_file: Optional[str]):
+def main(
+    source_file: str, destination_file: Optional[str], source_type: Optional[str] = None
+):
     """
     Convert2JUnit
 
@@ -26,7 +29,7 @@ def main(source_file: str, source_type: str, destination_file: Optional[str]):
         destination_file = os.path.splitext(source_file)[0] + ".xml"
 
     destination_file = os.path.abspath(destination_file)
-    candidate: Optional[Type[ReportFactory]] = available_reports.get(source_type)
+    candidate = fetch_report(source_file)
 
     if not callable(candidate):
         raise click.ClickException("Could not convert the report")

--- a/report2junit/reports/__init__.py
+++ b/report2junit/reports/__init__.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from typing import Dict, Type
+from typing import Type, Optional
 
 from report2junit.reports.report_factory import ReportFactory
 from report2junit.reports.cfn_nag import CfnNag
 from report2junit.reports.cfn_guard import CfnGuard
 
 
-available_reports: Dict[str, Type[ReportFactory]] = {
-    "cfn-guard": CfnGuard,
-    "cfn-nag": CfnNag,
-}
+def fetch_report(file: str) -> Optional[Type[ReportFactory]]:
+    with open(file, "rb") as fp:
+        data = fp.read()
+        for report in [CfnGuard, CfnNag]:
+            if report.compatible(data):
+                return report
+
+    return None

--- a/report2junit/reports/cfn_guard.py
+++ b/report2junit/reports/cfn_guard.py
@@ -17,6 +17,19 @@ class CfnGuard(ReportFactory):
 
         return self.__raw_source
 
+    @staticmethod
+    def compatible(data: bytes) -> bool:
+        try:
+            source = json.loads(data.decode("utf-8"))
+        except json.JSONDecodeError:
+            return False
+
+        return (
+            "compliant" in source
+            and "not_applicable" in source
+            and "not_compliant" in source
+        )
+
     def convert(self, destination: str) -> None:
         report = JunitReport("cfn-guard findings")
         any(map(report.success, self.raw_source.get("compliant", [])))

--- a/report2junit/reports/cfn_nag.py
+++ b/report2junit/reports/cfn_nag.py
@@ -17,6 +17,15 @@ class CfnNag(ReportFactory):
 
         return self.__raw_source
 
+    @staticmethod
+    def compatible(data: bytes) -> bool:
+        try:
+            source = json.loads(data.decode("utf-8"))
+        except json.JSONDecodeError:
+            return False
+
+        return "filename" in source[0] and "file_results" in source[0]
+
     def convert(self, destination: str) -> None:
         report = JunitReport("cfn-nag findings")
 

--- a/report2junit/reports/report_factory.py
+++ b/report2junit/reports/report_factory.py
@@ -12,3 +12,10 @@ class ReportFactory(ABC):
         """
         Convert the current report into a JUnit report and store it at the given destination.
         """
+
+    @staticmethod
+    @abstractmethod
+    def compatible(data: bytes) -> bool:
+        """
+        Returns True if the report can process the given data.
+        """

--- a/tests/reports/test_cfn_guard.py
+++ b/tests/reports/test_cfn_guard.py
@@ -1,0 +1,8 @@
+from report2junit.reports import fetch_report
+
+
+def test_cfn_guard(sample_report_path) -> None:
+    candidate = fetch_report(f"{sample_report_path}/cfn-guard.json")
+    report = candidate(f"{sample_report_path}/cfn-guard.json")
+
+    assert report.raw_source == report.raw_source

--- a/tests/reports/test_cfn_nag.py
+++ b/tests/reports/test_cfn_nag.py
@@ -1,7 +1,8 @@
-from report2junit.reports.cfn_nag import CfnNag
+from report2junit.reports import fetch_report
 
 
 def test_cfn_nag(sample_report_path) -> None:
-    report = CfnNag(f"{sample_report_path}/cfn-nag.json")
+    candidate = fetch_report(f"{sample_report_path}/cfn-nag.json")
+    report = candidate(f"{sample_report_path}/cfn-nag.json")
 
     assert report.raw_source == report.raw_source

--- a/tests/reports/test_no_report.py
+++ b/tests/reports/test_no_report.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch, mock_open
+
+from report2junit.reports import fetch_report
+
+
+def test_no_report(sample_report_path) -> None:
+    m = mock_open(read_data=b"invalid data")
+
+    with patch("report2junit.reports.open", m):
+        candidate = fetch_report(f"{sample_report_path}/no-report.json")
+
+    assert candidate is None

--- a/tests/test_report2junit.py
+++ b/tests/test_report2junit.py
@@ -1,7 +1,9 @@
 import os.path
+from unittest import mock
 from unittest.mock import mock_open, patch, MagicMock
 from click.testing import CliRunner
 from report2junit import main
+from report2junit.reports import CfnNag
 
 
 def expected_payload(name: str) -> str:
@@ -53,7 +55,8 @@ def test_cfn_guard_conversion_explicit_destination(sample_report_path: str) -> N
     assert result.exit_code == 0
 
 
-def test_cfn_nag_conversion(sample_report_path: str) -> None:
+@mock.patch("report2junit.fetch_report", return_value=CfnNag)
+def test_cfn_nag_conversion(_, sample_report_path: str) -> None:
     runner = CliRunner()
     m = mock_open()
 
@@ -73,7 +76,8 @@ def test_cfn_nag_conversion(sample_report_path: str) -> None:
     assert result.exit_code == 0
 
 
-def test_non_callable(sample_report_path) -> None:
+@mock.patch("report2junit.fetch_report", return_value=None)
+def test_non_callable(_, sample_report_path) -> None:
     runner = CliRunner()
 
     with patch("report2junit.callable", MagicMock(return_value=False)):


### PR DESCRIPTION
By using auto detection we will be able to process reports without to specify the type upfront.

Issue: #7