### PR TITLE
feat: improve data loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export BASH_ENV=$(VIRTUAL_ENV)/bin/activate
 lint: _black _mypy
 
 test: lint
-	pytest --cov --cov-report term-missing --junitxml=reports/pytest.xml --cov-report xml:reports/coverage.xml
+	pytest --cov --mypy --cov-report term-missing --junitxml=reports/pytest.xml --cov-report xml:reports/coverage.xml
 
 install: $(VIRTUAL_ENV)
 	poetry install

--- a/report2junit/reports/cfn_nag.py
+++ b/report2junit/reports/cfn_nag.py
@@ -1,30 +1,20 @@
 from __future__ import annotations
 
-import json
-
 from report2junit.reports.report_factory import ReportFactory
 from report2junit.reports.junit import JunitReport
 
 
 class CfnNag(ReportFactory):
-    __raw_source: dict = {}
+    @classmethod
+    def compatible(cls, data: bytes) -> bool:
+        source = cls._read_data(data)
 
-    @property
-    def raw_source(self) -> dict:
-        if not self.__raw_source:
-            with open(self.source_file) as f:
-                self.__raw_source = json.load(f)
-
-        return self.__raw_source
-
-    @staticmethod
-    def compatible(data: bytes) -> bool:
-        try:
-            source = json.loads(data.decode("utf-8"))
-        except json.JSONDecodeError:
+        if not isinstance(source, list):
             return False
 
-        return "filename" in source[0] and "file_results" in source[0]
+        entry: dict = next(iter(source), {})
+
+        return "filename" in entry and "file_results" in entry
 
     def convert(self, destination: str) -> None:
         report = JunitReport("cfn-nag findings")

--- a/report2junit/reports/report_factory.py
+++ b/report2junit/reports/report_factory.py
@@ -1,11 +1,30 @@
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class ReportFactory(ABC):
+    __raw_source: dict = {}
+
     def __init__(self, source: str):
         self.source_file = source
+
+    @property
+    def raw_source(self) -> dict:
+        if not self.__raw_source:
+            with open(self.source_file, "rb") as fp:
+                self.__raw_source = self._read_data(fp.read())
+
+        return self.__raw_source
+
+    @classmethod
+    def _read_data(cls, data: bytes) -> Any:
+        try:
+            return json.loads(data.decode("utf-8"))
+        except json.JSONDecodeError:
+            return {}
 
     @abstractmethod
     def convert(self, destination: str) -> None:
@@ -13,9 +32,9 @@ class ReportFactory(ABC):
         Convert the current report into a JUnit report and store it at the given destination.
         """
 
-    @staticmethod
+    @classmethod
     @abstractmethod
-    def compatible(data: bytes) -> bool:
+    def compatible(cls, data: bytes) -> bool:
         """
         Returns True if the report can process the given data.
         """

--- a/tests/reports/test_cfn_guard.py
+++ b/tests/reports/test_cfn_guard.py
@@ -3,6 +3,7 @@ from report2junit.reports import fetch_report
 
 def test_cfn_guard(sample_report_path) -> None:
     candidate = fetch_report(f"{sample_report_path}/cfn-guard.json")
-    report = candidate(f"{sample_report_path}/cfn-guard.json")
+    assert callable(candidate)
 
+    report = candidate(f"{sample_report_path}/cfn-guard.json")
     assert report.raw_source == report.raw_source

--- a/tests/reports/test_cfn_nag.py
+++ b/tests/reports/test_cfn_nag.py
@@ -3,6 +3,7 @@ from report2junit.reports import fetch_report
 
 def test_cfn_nag(sample_report_path) -> None:
     candidate = fetch_report(f"{sample_report_path}/cfn-nag.json")
-    report = candidate(f"{sample_report_path}/cfn-nag.json")
+    assert callable(candidate)
 
+    report = candidate(f"{sample_report_path}/cfn-nag.json")
     assert report.raw_source == report.raw_source

--- a/tests/reports/test_no_report.py
+++ b/tests/reports/test_no_report.py
@@ -9,4 +9,4 @@ def test_no_report(sample_report_path) -> None:
     with patch("report2junit.reports.open", m):
         candidate = fetch_report(f"{sample_report_path}/no-report.json")
 
-    assert candidate is None
+    assert not callable(candidate)


### PR DESCRIPTION
Move loading data to the abstract class. This will reduce the complexity in the actual report classes. And the majority of the reports are either json or yaml so no need to define this each time on a report level.