### PR TITLE
chore: remove deprecated option

### DIFF
--- a/report2junit/__init__.py
+++ b/report2junit/__init__.py
@@ -8,18 +8,11 @@ from report2junit.reports import AVAILABLE_REPORTS
 
 
 @click.command()
-@click.option(
-    # DEPRECATED source type is being auto-detected, this option will be removed in a future release.
-    "--source-type",
-    type=click.Choice(["cfn-guard", "cfn-nag"], case_sensitive=False),
-    required=False,
-)
 @click.argument("source-files", nargs=-1)
 @click.option("--destination-file", required=False)
 def main(
     source_files: str,
     destination_file: Optional[str],
-    source_type: Optional[str] = None,
 ):
     """
     Convert2JUnit


### PR DESCRIPTION
Since the deprecated option has already been released, see: [v0.1.0](https://github.com/Nr18/report2junit/releases/tag/v0.1.0) we will remove it in the next one.