### PR TITLE
feat: return non 0 exit code when there are failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ clean:
 	[[ -f .coverage ]] && rm .coverage || true
 
 run:
-	report2junit --source-type cfn-guard ./sample-reports/cfn-guard.json
-	report2junit --source-type cfn-nag ./sample-reports/cfn-nag.json
+	report2junit --ignore-failures ./sample-reports/cfn-guard.json ./sample-reports/cfn-nag.json
 
 build:
 	python setup.py sdist

--- a/README.md
+++ b/README.md
@@ -57,3 +57,17 @@ report2junit ./sample-reports/cfn-nag.json ./sample-reports/cfn-guard.json
 # Or if you want to specify the destination:
 report2junit ./sample-reports/cfn-nag.json ./sample-reports/cfn-guard.json --destination-file ./sample-reports/junit-other.xml
 ```
+
+In some cases it is useful to explicitly stop when there are failures. For example when you want to enforce that there
+are no failures. Or on the other hand we could continue when there are failures. This behaviour can be influenced using
+the `--ignore-failures` and `--fail-on-failures` options. Where `--fail-on-failures` is the default.
+
+```bash
+# Convert the given report and when there are failures exit code 1 is returned.
+report2junit ./sample-reports/cfn-guard.json --fail-on-failures
+echo $?
+
+# Convert the given report and when there are failures exit code 0 is returned.
+report2junit ./sample-reports/cfn-guard.json --ignore-failures
+echo $?
+```

--- a/report2junit/__init__.py
+++ b/report2junit/__init__.py
@@ -13,7 +13,7 @@ from report2junit.reports import AVAILABLE_REPORTS
 @click.option("--fail-on-failures/--ignore-failures", default=True)
 def main(
     source_files: List[str], destination_file: Optional[str], fail_on_failures: bool
-):
+) -> None:
     """
     Convert2JUnit
 
@@ -29,7 +29,7 @@ def main(
         )
 
 
-def apply_source_files(report: JUnitOutput, source_files: List[str]):
+def apply_source_files(report: JUnitOutput, source_files: List[str]) -> None:
     for source_file in source_files:
         source_file = os.path.abspath(source_file)
 

--- a/report2junit/__init__.py
+++ b/report2junit/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 import os.path
 import click
 
@@ -10,27 +10,40 @@ from report2junit.reports import AVAILABLE_REPORTS
 @click.command()
 @click.argument("source-files", nargs=-1)
 @click.option("--destination-file", required=False)
+@click.option("--fail-on-failures/--ignore-failures", default=True)
 def main(
-    source_files: str,
-    destination_file: Optional[str],
+    source_files: List[str], destination_file: Optional[str], fail_on_failures: bool
 ):
     """
     Convert2JUnit
 
     This tool allows you to convert various reports into the JUnit format.
     """
-    if not destination_file:
-        destination_file = os.path.join(os.path.dirname(source_files[0]), "junit.xml")
+    report = initialize_report(destination_file, source_files)
+    apply_source_files(report, source_files)
+    report.write()
 
-    report = JUnitOutput(destination_file)
+    if fail_on_failures and report.has_failures():
+        raise click.ClickException(
+            "report2junit detected that the report contains failures"
+        )
 
+
+def apply_source_files(report: JUnitOutput, source_files: List[str]):
     for source_file in source_files:
         source_file = os.path.abspath(source_file)
 
         if not report.apply(source_file):
             raise click.ClickException("Could not convert the report")
 
-    report.write()
+
+def initialize_report(
+    destination_file: Optional[str], source_files: List[str]
+) -> JUnitOutput:
+    if not destination_file:
+        destination_file = os.path.join(os.path.dirname(source_files[0]), "junit.xml")
+
+    return JUnitOutput(destination_file)
 
 
 if __name__ == "__main__":

--- a/report2junit/junit.py
+++ b/report2junit/junit.py
@@ -28,15 +28,13 @@ class JUnitOutput:
         self.__reports.append(report)
 
     def has_failures(self) -> bool:
+        def report_has_failures(report: TestSuite) -> bool:
+            return any(map(case_has_failures, report.test_cases))
+
         def case_has_failures(case: TestCase) -> bool:
             return len(case.failures) > 0
 
-        results: List[bool] = []
-
-        for report in self.__reports:
-            results.extend(map(case_has_failures, report.test_cases))
-
-        return any(results)
+        return any(map(report_has_failures, self.__reports))
 
     def write(self) -> None:
         if len(self.__reports) == 0:

--- a/report2junit/junit.py
+++ b/report2junit/junit.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 
 from typing import List
-from junit_xml import to_xml_report_string, TestSuite
+from junit_xml import to_xml_report_string, TestSuite, TestCase
 
 from report2junit.reports import Report
 
 
 class JUnitOutput:
+    __destination: str
+    __reports: List[TestSuite]
+
     def __init__(self, destination: str):
         self.__destination = destination
         self.__reports = self.__load_existing()
@@ -23,6 +26,17 @@ class JUnitOutput:
 
     def add_test_suite(self, report: TestSuite) -> None:
         self.__reports.append(report)
+
+    def has_failures(self) -> bool:
+        def case_has_failures(case: TestCase) -> bool:
+            return len(case.failures) > 0
+
+        results: List[bool] = []
+
+        for report in self.__reports:
+            results.extend(map(case_has_failures, report.test_cases))
+
+        return any(results)
 
     def write(self) -> None:
         if len(self.__reports) == 0:


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

When failures are reported in the destination report, you have two options:
- We should raise an exit code, this allows you to act on the error.
- We ignore it and return a 0 exit code, this allows us to ignore the results and continue as usual.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
