### PR TITLE
fix: release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: v${{ steps.vars.outputs.version }}
           release_name: Release v${{ steps.vars.outputs.version }}
           draft: false
           prerelease: false


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

By default it took the git ref as a tag. In my earlier tests I did test with version named tags. For this reason it worked before, but since the way of working have been changed it becomes an issue. By setting the tag to the actual version coming from the `pyproject.toml` file will solve this.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
